### PR TITLE
pyproject.toml: Register asyncio marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ profile = "black"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+markers = [
+    "asyncio",
+]


### PR DESCRIPTION
Register asyncio marker to avoid error:
  PytestUnknownMarkWarning: Unknown pytest.mark.asyncio